### PR TITLE
Fix mitts likes concurrency 

### DIFF
--- a/internal/db/migrations/00003_mitts_likes.sql
+++ b/internal/db/migrations/00003_mitts_likes.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS mitts_likes (
     id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
     user_id UUID NOT NULL REFERENCES users(id),
     mitt_id UUID NOT NULL REFERENCES mitts(id) ON DELETE CASCADE,
-    liked_at TIMESTAMP DEFAULT NOW()
+    liked_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE (user_id, mitt_id)
 );
 -- +goose StatementEnd
 

--- a/internal/db/sqlc/queries/mitts.sql
+++ b/internal/db/sqlc/queries/mitts.sql
@@ -85,10 +85,6 @@ INSERT INTO mitts_likes (
     @user_id, @mitt_id
 );
 
--- name: IsMittLikedByUser :one
-SELECT 1 FROM mitts_likes
-WHERE user_id = @user_id AND mitt_id = @mitt_id;
-
 -- name: DeleteMittLike :exec
 DELETE FROM mitts_likes
 WHERE user_id = @user_id AND mitt_id = @mitt_id;

--- a/internal/db/sqlc/storage/mitts.sql.go
+++ b/internal/db/sqlc/storage/mitts.sql.go
@@ -251,23 +251,6 @@ func (q *Queries) GetMitt(ctx context.Context, id uuid.UUID) (GetMittRow, error)
 	return i, err
 }
 
-const isMittLikedByUser = `-- name: IsMittLikedByUser :one
-SELECT 1 FROM mitts_likes
-WHERE user_id = $1 AND mitt_id = $2
-`
-
-type IsMittLikedByUserParams struct {
-	UserID uuid.UUID
-	MittID uuid.UUID
-}
-
-func (q *Queries) IsMittLikedByUser(ctx context.Context, arg IsMittLikedByUserParams) (int32, error) {
-	row := q.db.QueryRow(ctx, isMittLikedByUser, arg.UserID, arg.MittID)
-	var column_1 int32
-	err := row.Scan(&column_1)
-	return column_1, err
-}
-
 const likeMitt = `-- name: LikeMitt :exec
 INSERT INTO mitts_likes (
     user_id, mitt_id

--- a/internal/models/mitt_repo.go
+++ b/internal/models/mitt_repo.go
@@ -18,7 +18,6 @@ type MittRepository interface {
 	// Likes
 
 	LikeMitt(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) error
-	IsMittLikedByUser(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) (bool, error)
 	DeleteMittLike(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) error
 
 	Feed(ctx context.Context, limit, offset int32) ([]*Mitt, error)

--- a/internal/repository/mitt.go
+++ b/internal/repository/mitt.go
@@ -2,9 +2,7 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/misshanya/mitter/internal/db/sqlc/storage"
 	"github.com/misshanya/mitter/internal/models"
 )
@@ -117,20 +115,6 @@ func (r *MittRepository) LikeMitt(ctx context.Context, userID uuid.UUID, mittID 
 		UserID: userID,
 		MittID: mittID,
 	})
-}
-
-func (r *MittRepository) IsMittLikedByUser(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) (bool, error) {
-	_, err := r.queries.IsMittLikedByUser(ctx, storage.IsMittLikedByUserParams{
-		UserID: userID,
-		MittID: mittID,
-	})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func (r *MittRepository) DeleteMittLike(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) error {

--- a/internal/service/mitt/mitt.go
+++ b/internal/service/mitt/mitt.go
@@ -140,50 +140,61 @@ func (s *Service) DeleteMitt(ctx context.Context, userID uuid.UUID, mittID uuid.
 
 // Likes
 
-func (s *Service) SwitchLike(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) (bool, *models.HTTPError) {
-	isAlreadyLiked, err := s.mr.IsMittLikedByUser(ctx, userID, mittID)
+func (s *Service) addLike(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) error {
+	err := s.mr.LikeMitt(ctx, userID, mittID)
 	if err != nil {
-		s.l.Error("error getting isAlreadyLiked", slog.Any("err", err))
+		return err
+	}
+
+	// Add like in metrics
+	go s.mm.AddLike()
+
+	return nil
+}
+
+func (s *Service) deleteLike(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) error {
+	err := s.mr.DeleteMittLike(ctx, userID, mittID)
+	if err != nil {
+		return err
+	}
+
+	// Delete like in metrics
+	go s.mm.DeleteLike()
+
+	return nil
+}
+
+func (s *Service) SwitchLike(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) (bool, *models.HTTPError) {
+	err := s.addLike(ctx, userID, mittID)
+	if err != nil && !pgutil.IsUniqueViolation(err) {
+		// If mitt doesn't exist
+		if pgutil.IsForeignKeyViolation(err) {
+			return false, &models.HTTPError{
+				Code:    http.StatusNotFound,
+				Message: "Mitt doesn't exist",
+			}
+		}
+
+		s.l.Error("error liking mitt", slog.Any("err", err))
 		return false, &models.HTTPError{
 			Code:    http.StatusInternalServerError,
 			Message: "Internal server error",
 		}
-	}
-
-	if !isAlreadyLiked {
-		if err := s.mr.LikeMitt(ctx, userID, mittID); err != nil {
-			if pgutil.IsForeignKeyViolation(err) {
-				return false, &models.HTTPError{
-					Code:    http.StatusNotFound,
-					Message: "Mitt doesn't exist",
-				}
-			}
-
-			s.l.Error("error liking mitt", slog.Any("err", err))
+	} else if pgutil.IsUniqueViolation(err) {
+		// Delete like
+		err := s.deleteLike(ctx, userID, mittID)
+		if err != nil {
+			s.l.Error("error deleting mitt like", slog.Any("err", err))
 			return false, &models.HTTPError{
 				Code:    http.StatusInternalServerError,
 				Message: "Internal server error",
 			}
 		}
 
-		// Add like in metrics
-		go s.mm.AddLike()
-
-		return true, nil
+		return false, nil
 	}
 
-	if err := s.mr.DeleteMittLike(ctx, userID, mittID); err != nil {
-		s.l.Error("error deleting mitt like", slog.Any("err", err))
-		return false, &models.HTTPError{
-			Code:    http.StatusInternalServerError,
-			Message: "Internal server error",
-		}
-	}
-
-	// Delete like in metrics
-	go s.mm.DeleteLike()
-
-	return false, nil
+	return true, nil
 }
 
 func (s *Service) Feed(ctx context.Context, limit, offset int32) ([]*models.Mitt, *models.HTTPError) {

--- a/internal/service/mitt/mitt_mock.go
+++ b/internal/service/mitt/mitt_mock.go
@@ -2,6 +2,7 @@ package mitt
 
 import (
 	"context"
+	"github.com/jackc/pgx/v5/pgconn"
 	"log/slog"
 	"os"
 	"time"
@@ -24,7 +25,9 @@ var mockUserID = uuid.New()
 var testLogger = slog.New(slog.NewTextHandler(os.Stdin, &slog.HandlerOptions{}))
 
 // Mock mitt repo
-type mockMittRepo struct{}
+type mockMittRepo struct {
+	isLikeUniqueViolation bool
+}
 
 func (m mockMittRepo) CreateMitt(ctx context.Context, userID uuid.UUID, mitt *models.MittCreate) (*models.Mitt, error) {
 	_ = ctx
@@ -68,6 +71,10 @@ func (m mockMittRepo) DeleteMitt(ctx context.Context, mittID uuid.UUID) error {
 	return nil
 }
 
+func (m *mockMittRepo) SwitchLikeUniqueViolation() {
+	m.isLikeUniqueViolation = !m.isLikeUniqueViolation
+}
+
 func (m mockMittRepo) LikeMitt(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) error {
 	_ = ctx
 	_ = userID
@@ -76,16 +83,13 @@ func (m mockMittRepo) LikeMitt(ctx context.Context, userID uuid.UUID, mittID uui
 	// Add like to mock mitt
 	mockMittModel.Likes++
 
+	if m.isLikeUniqueViolation {
+		return &pgconn.PgError{
+			Code: "23505",
+		}
+	}
+
 	return nil
-}
-
-func (m mockMittRepo) IsMittLikedByUser(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) (bool, error) {
-	_ = ctx
-	_ = userID
-	_ = mittID
-
-	// Let's assume that if mock model has >=1 like, mitt is liked by user, if less, no
-	return mockMittModel.Likes >= 1, nil
 }
 
 func (m mockMittRepo) DeleteMittLike(ctx context.Context, userID uuid.UUID, mittID uuid.UUID) error {

--- a/internal/service/mitt/mitt_test.go
+++ b/internal/service/mitt/mitt_test.go
@@ -79,7 +79,8 @@ func TestMittService_DeleteMitt(t *testing.T) {
 }
 
 func TestMittService_SwitchLike(t *testing.T) {
-	service := NewService(mockMittRepo{}, &mockMittMetrics{}, &mockUserRepo{}, testLogger)
+	mmr := mockMittRepo{}
+	service := NewService(&mmr, &mockMittMetrics{}, &mockUserRepo{}, testLogger)
 	ctx := context.Background()
 
 	// Like mitt
@@ -91,6 +92,9 @@ func TestMittService_SwitchLike(t *testing.T) {
 	if !newState {
 		t.Fatal("liked state should be true")
 	}
+
+	// Return unique violation in mock
+	mmr.SwitchLikeUniqueViolation()
 
 	// Remove like
 	newState, err = service.SwitchLike(ctx, mockUserID, mockMittModel.ID)


### PR DESCRIPTION
- Use unique violation to check if mitt is liked by user
- Update tests with unique violation

And we have only 1 sql query to like mitt instead of 2 (check and like)